### PR TITLE
Feature/optionally preserve or remove config files created from link files

### DIFF
--- a/src/Sitecore.ConfigBuilder.Tool/ConfigBuilderProxy.cs
+++ b/src/Sitecore.ConfigBuilder.Tool/ConfigBuilderProxy.cs
@@ -76,8 +76,11 @@ namespace Sitecore.ConfigBuilder.Tool
           string destFolder = Path.GetDirectoryName(pair.Key);
           string fileName = Path.GetFileName(pair.Value);
           string destFullPath = Path.Combine(destFolder, fileName);
-          File.Copy(pair.Value, destFullPath);
-          createdFiles.Add(destFullPath);
+          if (!File.Exists(destFullPath))
+          {
+            File.Copy(pair.Value, destFullPath);
+            createdFiles.Add(destFullPath);
+          }          
         }
       }
       return createdFiles;

--- a/src/Sitecore.ConfigBuilder.Tool/ConfigBuilderProxy.cs
+++ b/src/Sitecore.ConfigBuilder.Tool/ConfigBuilderProxy.cs
@@ -79,8 +79,8 @@ namespace Sitecore.ConfigBuilder.Tool
           if (!File.Exists(destFullPath))
           {
             File.Copy(pair.Value, destFullPath);
-            createdFiles.Add(destFullPath);
-          }          
+            // createdFiles.Add(destFullPath); usage in future is expected
+          }
         }
       }
       return createdFiles;
@@ -126,7 +126,7 @@ namespace Sitecore.ConfigBuilder.Tool
     {
       IList<string> createdFiles = CreateRealConfigs(webConfigFilePath);
       XmlDocument result = Sitecore.Diagnostics.ConfigBuilder.ConfigBuilder.Build(webConfigFilePath, buildWebConfigResult, normalizeOutput);
-      RemoveRealConfigs(createdFiles);
+      // RemoveRealConfigs(createdFiles); usage in future is expected
       return result;
     }
 
@@ -134,7 +134,7 @@ namespace Sitecore.ConfigBuilder.Tool
     {
       IList<string> createdFiles = CreateRealConfigs(webConfigFilePath);
       XmlDocument result = Sitecore.Diagnostics.ConfigBuilder.ConfigBuilder.Build(webConfigFilePath, buildWebConfigResult, normalizeOutput, fileSystem);
-      RemoveRealConfigs(createdFiles);
+      // RemoveRealConfigs(createdFiles);  usage in future is expected
       return result;
     }
 
@@ -142,14 +142,14 @@ namespace Sitecore.ConfigBuilder.Tool
     {
       IList<string> createdFiles = CreateRealConfigs(webConfigFilePath);
       Sitecore.Diagnostics.ConfigBuilder.ConfigBuilder.Build(webConfigFilePath, outputFilePath, buildWebConfigResult, normalizeOutput);
-      RemoveRealConfigs(createdFiles);
+      // RemoveRealConfigs(createdFiles); usage in future is expected
     }
 
     public static void Build(string webConfigFilePath, string outputFilePath, bool buildWebConfigResult, bool normalizeOutput, IFileSystem fileSystem)
     {
       IList<string> createdFiles = CreateRealConfigs(webConfigFilePath);
       Sitecore.Diagnostics.ConfigBuilder.ConfigBuilder.Build(webConfigFilePath, outputFilePath, buildWebConfigResult, normalizeOutput, fileSystem);
-      RemoveRealConfigs(createdFiles);
+      // RemoveRealConfigs(createdFiles); usage in future is expected
     }
   }
 }

--- a/src/Sitecore.ConfigBuilder.Tool/ConfigBuilderProxy.cs
+++ b/src/Sitecore.ConfigBuilder.Tool/ConfigBuilderProxy.cs
@@ -109,6 +109,19 @@ namespace Sitecore.ConfigBuilder.Tool
       }
     }
 
+    public static string ConvertLinkToRealFile(string linkPath)
+    {
+      string result = linkPath;
+      if (!string.IsNullOrWhiteSpace(linkPath) && linkPath.EndsWith(linkExtension))
+      {
+        var dict = new Dictionary<string, string>();
+        dict.Add(string.Empty, linkPath);
+        ConvertLinkToRealFile(dict);
+        result = dict[string.Empty];
+      }
+      return result;
+    }
+
     public static XmlDocument Build(string webConfigFilePath, bool buildWebConfigResult, bool normalizeOutput)
     {
       IList<string> createdFiles = CreateRealConfigs(webConfigFilePath);

--- a/src/Sitecore.ConfigBuilder.Tool/MainForm.cs
+++ b/src/Sitecore.ConfigBuilder.Tool/MainForm.cs
@@ -294,7 +294,7 @@
         {
           try
           {
-            return ServiceClient.Create().GetVersions("Sitecore CMS");
+            return ServiceClient.Create().GetVersions("Sitecore CMS").OrderByDescending(v => v.Version.MajorMinorUpdateInt);
           }
           catch (Exception ex)
           {

--- a/src/Sitecore.ConfigBuilder.Tool/MainForm.cs
+++ b/src/Sitecore.ConfigBuilder.Tool/MainForm.cs
@@ -21,7 +21,7 @@
   {
     #region Fields and Constants
 
-    private const string WebConfigOpenFilter = "*.config|*.config|Any file|*";
+    private const string WebConfigOpenFilter = "*.config|*.config|*.link|*.link|Any file|*";
 
     private const string SaveFilter = "*.xml|*.xml|Any file|*";
 
@@ -59,6 +59,7 @@
       try
       {
         var webConfigPath = this.FilePathTextbox.Text.Trim(" \"".ToCharArray());
+        webConfigPath = ConfigBuilderProxy.ConvertLinkToRealFile(webConfigPath);
         var buildWebConfigResult = this.BuildWebConfigResult.Checked;
         var normalizeOutput = this.NormalizeOutput.Checked;
         var requireDefaultConfiguration = this.RequireDefaultConfiguration.Checked;

--- a/src/Sitecore.ConfigBuilder.Tool/WinAPI.cs
+++ b/src/Sitecore.ConfigBuilder.Tool/WinAPI.cs
@@ -95,6 +95,14 @@ namespace Sitecore.ConfigBuilder.Tool
           key = classesRoot.CreateSubKey(@"*\shell\Sitecore.ConfigBuilder\command");
           key.SetValue("", "\"" + ConfigBuilderExePath + "\" \"%1\"");
 
+          key = classesRoot.CreateSubKey(@"*\shell\Sitecore.ConfigBuilder.ConfigLink");
+          key.SetValue("", "Open with Sitecore Config Builder");
+          key.SetValue("Icon", ConfigBuilderExePath);
+          key.SetValue("AppliesTo", "System.FileName:\"web.config*.link\"");
+
+          key = classesRoot.CreateSubKey(@"*\shell\Sitecore.ConfigBuilder.ConfigLink\command");
+          key.SetValue("", "\"" + ConfigBuilderExePath + "\" \"%1\"");
+
           key = classesRoot.CreateSubKey(@"*\shell\Sitecore.ConfigBuilder.ConfigDisable");
           key.SetValue("", "Disable configuration file");
           key.SetValue("Icon", ConfigBuilderExePath);


### PR DESCRIPTION
-> Existing config files are not overwritten
-> web.config.link files can be added using UI and a context menu on a file
-> When creating configs based on links, configs are not deleted
-> After recent changes, (Step 5) dropdown with versions started to show versions in the ascending order, reverted back to descending order