### PR TITLE
Version 1.6.0.9 to support XP 9.3 with Microsoft.Configuration.Config…

### DIFF
--- a/src/Sitecore.ConfigBuilder.Tool/Properties/AssemblyInfo.cs
+++ b/src/Sitecore.ConfigBuilder.Tool/Properties/AssemblyInfo.cs
@@ -13,6 +13,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("1.6.0.8")]
-[assembly: AssemblyFileVersion("1.6.0.8")]
-[assembly: AssemblyInformationalVersion("1.6 rev. 191224")]
+[assembly: AssemblyVersion("1.6.0.9")]
+[assembly: AssemblyFileVersion("1.6.0.9")]
+[assembly: AssemblyInformationalVersion("1.6 rev. 191225")]


### PR DESCRIPTION
No code changes. Final ZIP archive with a Config Builder contains extra DLLs:
-> Microsoft.Configuration.ConfigurationBuilders.Environment.dll
-> Microsoft.Configuration.ConfigurationBuilders.Base.dll
taken from clean XP 9.3 solution.
Assemblies are required to build XP 9.3 showconfig.